### PR TITLE
Make the 'hand size' an option: unlimited (like today) or 8

### DIFF
--- a/gameoptions.inc.php
+++ b/gameoptions.inc.php
@@ -7,6 +7,7 @@ const OptGameDuration = 100;
 const OptSkipOn = 101;
 const OptRevolutionOn = 102;
 const OptJokersOn = 103;
+const OptMaxCardsPerPlayerHand = 104;
 
 $game_options = [
     // note: game variant ID should start at 100 (ie: 100, 101, 102, ...). The maximum is 199.
@@ -56,6 +57,19 @@ $game_options = [
                 'name' => totranslate('On'),
                 'description' => totranslate('2 Jokers will be added to the deck; A Joker beats any hand (except a Joker) and is unaffected by Revolution')
             ]
+        ]
+    ],
+    OptMaxCardsPerPlayerHand => [
+        'name' => totranslate('Max Number of Cards per Player'),
+        'values' => [
+            14 => [
+                'name' => totranslate('Unlimited'),
+                'description' => totranslate('A full deck of cards will be used (plus optionally Jokers); this translates to up to 14 cards per player in a 4-player game')
+            ],
+            8 => [
+                'name' => totranslate('8'),
+                'description' => totranslate('Players will start with up to 8 hands in hand. Irrelevant for 7 and 8 player games, as there are not enough cards in a deck to deal that many anyway')
+            ],
         ]
     ]
 ];

--- a/president.game.php
+++ b/president.game.php
@@ -131,24 +131,8 @@ class President extends Table
 
         // Create deck, starting from the highest card
         $cards = [];
-        $highestCardToInsert = 15;
-        $lowestCardToInsert = 3;
-        $maxNumberOfCardsPerPlayer = 13;
-        $maxNumberOfCards = $maxNumberOfCardsPerPlayer * $numberOfPlayers;
+
         $optionJokersOn = $this->gamestate->table_globals[Opt::jokersOn];
-        $maxNumberOfNormalCards = $optionJokersOn ? $maxNumberOfCards - 2 : $maxNumberOfCards;
-
-        for ($value = $highestCardToInsert; $value >= $lowestCardToInsert; $value --) {
-            // spade, heart, diamond, club
-            foreach ( $this->colors as $color_id => $color ) {
-                $cards [] = ['type' => $color_id,'type_arg' => $value,'nbr' => 1 ];
-                if (count($cards) >= $maxNumberOfNormalCards)
-                    break;
-            }
-            if (count($cards) >= $maxNumberOfNormalCards)
-            break;
-        }
-
         if ($optionJokersOn) {
             foreach ($this->special_cards as $special_card) {
                 $cards [] = [
@@ -157,6 +141,22 @@ class President extends Table
                     'nbr' => $special_card['nbr']
                 ];
             }
+        }
+
+        $highestCardToInsert = 15;
+        $lowestCardToInsert = 3;
+        $maxNumberOfCardsPerPlayer = 13;
+        $maxNumberOfCards = $maxNumberOfCardsPerPlayer * $numberOfPlayers;
+
+        for ($value = $highestCardToInsert; $value >= $lowestCardToInsert; $value --) {
+            // spade, heart, diamond, club
+            foreach ( $this->colors as $color_id => $color ) {
+                $cards [] = ['type' => $color_id,'type_arg' => $value,'nbr' => 1 ];
+                if (count($cards) >= $maxNumberOfCards)
+                    break;
+            }
+            if (count($cards) >= $maxNumberOfCards)
+            break;
         }
 
         $this->cards->createCards( $cards, 'deck' );

--- a/president.game.php
+++ b/president.game.php
@@ -19,6 +19,7 @@ class GS {
     public const optSkipOn = "optSkipOn";
     public const optRevolutionOn = "optRevolutionOn";
     public const optJokersOn = "optJokersOn";
+    public const optMaxCardsPerPlayerHand = "optMaxCardsPerPlayerHand";
 }
 
 class Opt {
@@ -26,6 +27,7 @@ class Opt {
     public const skipOn = 101;
     public const revolutionOn = 102;
     public const jokersOn = 103;
+    public const maxCardsPerPlayerHand = 104;
 }
 
 class President extends Table
@@ -55,6 +57,7 @@ class President extends Table
             GS::optSkipOn => Opt::skipOn,
             GS::optRevolutionOn => Opt::revolutionOn,
             GS::optJokersOn => Opt::jokersOn,
+            GS::optMaxCardsPerPlayerHand => Opt::maxCardsPerPlayerHand,
         ]);
 
         $this->cards = self::getNew( "module.common.deck" );
@@ -145,7 +148,7 @@ class President extends Table
 
         $highestCardToInsert = 15;
         $lowestCardToInsert = 3;
-        $maxNumberOfCardsPerPlayer = 13;
+        $maxNumberOfCardsPerPlayer = $this->gamestate->table_globals[Opt::maxCardsPerPlayerHand];
         $maxNumberOfCards = $maxNumberOfCardsPerPlayer * $numberOfPlayers;
 
         for ($value = $highestCardToInsert; $value >= $lowestCardToInsert; $value --) {
@@ -156,7 +159,7 @@ class President extends Table
                     break;
             }
             if (count($cards) >= $maxNumberOfCards)
-            break;
+                break;
         }
 
         $this->cards->createCards( $cards, 'deck' );


### PR DESCRIPTION
Where I come from, we always play Presidents with 4 persons, cards dealt 7 and up (no 2's, no jokers). Makes for a much faster game, with in my experience switches between roles more likely.

This PR allows playing 8-card hands (but still with the 8>A>2 deck, or with a 88>9999>>AAAA>2222>JkJk deck)
